### PR TITLE
Pull Dialpad API key from an environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@
 # vendor/
 
 # Terraform example directory
-.terraform
+.terraform*

--- a/dialpad/client.go
+++ b/dialpad/client.go
@@ -8,35 +8,35 @@ import (
 	"net/http"
 )
 
-type DialpadError struct {
+type dialpadError struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
 }
 
-type DialpadErrorWrapper struct {
-	Error DialpadError `json:"error"`
+type dialpadErrorWrapper struct {
+	Error dialpadError `json:"error"`
 }
 
-type Client struct {
+type client struct {
 	HttpClient *http.Client
-	Token      string
+	ApiKey     string
 }
 
-func NewClient(token string) *Client {
-	client := Client{
+func NewClient(apiKey string) *client {
+	client := client{
 		HttpClient: &http.Client{},
-		Token:      token,
+		ApiKey:     apiKey,
 	}
 
 	return &client
 }
 
-func (c *Client) NewRequest(method string, path string, body io.Reader) (*http.Request, error) {
+func (c *client) NewRequest(method string, path string, body io.Reader) (*http.Request, error) {
 	return http.NewRequest(method, fmt.Sprintf("https://dialpad.com/api/v2%s", path), body)
 }
 
-func (c *Client) Do(req *http.Request) ([]byte, error) {
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.Token))
+func (c *client) Do(req *http.Request) ([]byte, error) {
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.ApiKey))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
 
@@ -53,7 +53,7 @@ func (c *Client) Do(req *http.Request) ([]byte, error) {
 	}
 
 	if res.StatusCode >= 400 {
-		dialpadError := &DialpadErrorWrapper{}
+		dialpadError := &dialpadErrorWrapper{}
 
 		err = json.Unmarshal(body, &dialpadError)
 		if err != nil {

--- a/dialpad/provider.go
+++ b/dialpad/provider.go
@@ -11,10 +11,11 @@ import (
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
-			"token": {
-				Type:      schema.TypeString,
-				Required:  true,
-				Sensitive: true,
+			"api_key": {
+				Type:        schema.TypeString,
+				DefaultFunc: schema.EnvDefaultFunc("DIALPAD_API_KEY", nil),
+				Required:    true,
+				Sensitive:   true,
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
@@ -29,8 +30,8 @@ func Provider() *schema.Provider {
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	token := d.Get("token").(string)
-	client := NewClient(token)
+	apiKey := d.Get("api_key").(string)
+	client := NewClient(apiKey)
 
 	return client, diags
 }

--- a/dialpad/resource_call_subscription.go
+++ b/dialpad/resource_call_subscription.go
@@ -50,7 +50,7 @@ func resourceCallSubscriptionRead(ctx context.Context, d *schema.ResourceData, m
 	var diags diag.Diagnostics
 
 	subId := d.Id()
-	client := m.(*Client)
+	client := m.(*client)
 
 	req, err := client.NewRequest("GET", fmt.Sprintf("/subscriptions/call/%s", subId), nil)
 
@@ -78,7 +78,7 @@ func resourceCallSubscriptionRead(ctx context.Context, d *schema.ResourceData, m
 }
 
 func resourceCallSubscriptionCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*Client)
+	client := m.(*client)
 
 	statesSet := d.Get("call_states").(*schema.Set).List()
 	states := make([]string, len(statesSet))
@@ -119,7 +119,7 @@ func resourceCallSubscriptionCreate(ctx context.Context, d *schema.ResourceData,
 }
 
 func resourceCallSubscriptionUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*Client)
+	client := m.(*client)
 	id := d.Id()
 
 	statesSet := d.Get("call_states").(*schema.Set).List()
@@ -153,7 +153,7 @@ func resourceCallSubscriptionUpdate(ctx context.Context, d *schema.ResourceData,
 
 func resourceCallSubscriptionDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	client := m.(*Client)
+	client := m.(*client)
 
 	id := d.Id()
 

--- a/dialpad/resource_webhook.go
+++ b/dialpad/resource_webhook.go
@@ -56,7 +56,7 @@ func resourceWebhookRead(ctx context.Context, d *schema.ResourceData, m interfac
 	var diags diag.Diagnostics
 
 	hookId := d.Id()
-	client := m.(*Client)
+	client := m.(*client)
 
 	req, err := client.NewRequest("GET", fmt.Sprintf("/webhooks/%s", hookId), nil)
 
@@ -84,7 +84,7 @@ func resourceWebhookRead(ctx context.Context, d *schema.ResourceData, m interfac
 }
 
 func resourceWebhookCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*Client)
+	client := m.(*client)
 
 	hookRequest := webhookRequest{
 		HookUrl: d.Get("hook_url").(string),
@@ -123,7 +123,7 @@ func resourceWebhookCreate(ctx context.Context, d *schema.ResourceData, m interf
 }
 
 func resourceWebhookUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*Client)
+	client := m.(*client)
 	id := d.Id()
 
 	hookRequest := webhookRequest{
@@ -155,7 +155,7 @@ func resourceWebhookUpdate(ctx context.Context, d *schema.ResourceData, m interf
 
 func resourceWebhookDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	client := m.(*Client)
+	client := m.(*client)
 
 	id := d.Id()
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "dialpad" {
-  token = "My-Api-Key"
+  api_key = "My-Api-Key"
 }
 
 resource "dialpad_webhook" "example" {


### PR DESCRIPTION
If the key is not provided via the provider configuration, pull it in using an environment variable. For consistency, rename token to api_key everywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/story-health/terraform-provider-dialpad/2)
<!-- Reviewable:end -->
